### PR TITLE
Cost volume dev

### DIFF
--- a/pwcnet/cost_volume/cost_volume.py
+++ b/pwcnet/cost_volume/cost_volume.py
@@ -15,18 +15,19 @@ def cost_volume(c1, c2, search_range=4):
     """
     with tf.name_scope('cost_volume'):
         square_len = 2 * search_range + 1
-
-        # cv is cost volume, not OpenCV.
         square_area = square_len ** 2
         cv_shape = tf.concat([tf.shape(c1)[:-1], [square_area]], axis=0)
+        c1_transposed = tf.transpose(c1, [1, 2, 3, 0])
+        c2_transposed = tf.transpose(c2, [1, 2, 3, 0])
 
         # Form an index matrix to help us update sparsely later on.
         cv_height, cv_width = cv_shape[1], cv_shape[2]
-        x_1d, y_1d = tf.range(0, cv_width), tf.range(0, cv_height)
-        x_2d, y_2d = tf.meshgrid(x_1d, y_1d)
-        indices_2d = tf.stack([y_2d, x_2d], axis=-1)
+        x_1d, y_1d, z_1d = tf.range(0, cv_width), tf.range(0, cv_height), tf.range(0, square_area)
+        x_2d, y_2d, z_2d = tf.meshgrid(x_1d, y_1d, z_1d)
+        indices_3d = tf.stack([y_2d, x_2d, z_2d], axis=-1)
 
         all_indices, all_costs = [], []
+        c1_regions, c2_regions = [], []
         cur_z_index = square_area - 1
         for i in range(-search_range, search_range + 1):
             for j in range(-search_range, search_range + 1):
@@ -49,10 +50,7 @@ def cost_volume(c1, c2, search_range=4):
                 costs = tf.reduce_mean(c1[:, slice_h, slice_w, :] * c2[:, slice_h_r, slice_w_r, :], axis=-1)
 
                 # Get the coordinates for scatter update, where each element is a (y, x, z) coordinate.
-                cur_indices = indices_2d[slice_h, slice_w]
-                z_indices = tf.cast(cur_z_index * tf.ones(tf.shape(cur_indices)[:-1]), tf.int32)
-                z_indices = tf.expand_dims(z_indices, axis=-1)
-                cur_indices = tf.concat([cur_indices, z_indices], axis=-1)
+                cur_indices = indices_3d[slice_h, slice_w, cur_z_index]
                 cur_indices = tf.reshape(cur_indices, (-1, 3))
 
                 # The batch dimension needs to be moved to the end to make slicing work correctly.
@@ -60,10 +58,82 @@ def cost_volume(c1, c2, search_range=4):
                 costs = tf.transpose(costs, [1, 0])
                 all_costs.append(costs)
                 all_indices.append(cur_indices)
+                c1_regions.append(c1_transposed[slice_h, slice_w, :, :])
+                c2_regions.append(c2_transposed[slice_h_r, slice_w_r, :, :])
                 cur_z_index -= 1
 
         all_costs = tf.concat(all_costs[::-1], axis=0)
         all_indices = tf.concat(all_indices[::-1], axis=0)
+        batch_dim = tf.shape(c1)[0]
+        target_shape = [cv_height, cv_width, square_area, batch_dim]
+        cv = tf.scatter_nd(all_indices, all_costs, target_shape)
+        cv = tf.transpose(cv, [3, 0, 1, 2])
+        return cv
+
+
+def cost_volume_grouped_reduce(c1, c2, search_range=4):
+    """
+    See https://arxiv.org/pdf/1709.02371.pdf.
+    For each pixel in c1, we will compute correlations with its spatial neighbors in c2.
+    :param c1: Tensor. Feature map of shape [batch_size, H, W, num_features].
+    :param c2: Input tensor with the exact same shape as c1.
+    :param search_range: The search square's side length is equal to 2 * search_range + 1.
+    :return: Tensor. Cost volume of shape [batch_size, H, W, s * s], where s is equal to 2 * search_range + 1.
+    """
+    with tf.name_scope('cost_volume'):
+        square_len = 2 * search_range + 1
+        square_area = square_len ** 2
+        cv_shape = tf.concat([tf.shape(c1)[:-1], [square_area]], axis=0)
+
+        # The batch dimension needs to be moved to the end to make slicing work correctly.
+        c1_transposed = tf.transpose(c1, [1, 2, 3, 0])
+        c2_transposed = tf.transpose(c2, [1, 2, 3, 0])
+
+        # Form an index matrix to help us update sparsely later on.
+        cv_height, cv_width = cv_shape[1], cv_shape[2]
+        x_1d, y_1d, z_1d = tf.range(0, cv_width), tf.range(0, cv_height), tf.range(0, square_area)
+        x_2d, y_2d, z_2d = tf.meshgrid(x_1d, y_1d, z_1d)
+        indices_3d = tf.stack([y_2d, x_2d, z_2d], axis=-1)
+
+        all_indices, all_costs = [], []
+        all_c1_regions, all_c2_regions = [], []
+        cur_z_index = square_area - 1
+        num_channels = tf.shape(c1)[-1]
+        batch_size = tf.shape(c1)[0]
+        for i in range(-search_range, search_range + 1):
+            for j in range(-search_range, search_range + 1):
+
+                # Note that 'Python'[slice(None)] returns 'Python'.
+                if i < 0:
+                    slice_h, slice_h_r = slice(None, i), slice(-i, None)
+                elif i > 0:
+                    slice_h, slice_h_r = slice(i, None), slice(None, -i)
+                else:
+                    slice_h, slice_h_r = slice(None), slice(None)
+
+                if j < 0:
+                    slice_w, slice_w_r = slice(None, j), slice(-j, None)
+                elif j > 0:
+                    slice_w, slice_w_r = slice(j, None), slice(None, -j)
+                else:
+                    slice_w, slice_w_r = slice(None), slice(None)
+
+                # Get the coordinates for scatter update, where each element is a (y, x, z) coordinate.
+                cur_indices = indices_3d[slice_h, slice_w, cur_z_index]
+                cur_indices = tf.reshape(cur_indices, (-1, 3))
+                c1_region = c1_transposed[slice_h, slice_w, :, :]
+                c1_region = tf.reshape(c1_region, (-1, num_channels, batch_size))
+                c2_region = c2_transposed[slice_h_r, slice_w_r, :, :]
+                c2_region = tf.reshape(c2_region, (-1, num_channels, batch_size))
+                all_indices.append(cur_indices)
+                all_c1_regions.append(c1_region)
+                all_c2_regions.append(c2_region)
+                cur_z_index -= 1
+
+        all_indices = tf.concat(all_indices[::-1], axis=0)
+        all_c1_regions = tf.concat(all_c1_regions[::-1], axis=0)
+        all_c2_regions = tf.concat(all_c2_regions[::-1], axis=0)
+        all_costs = tf.reduce_mean(all_c1_regions * all_c2_regions, axis=1)
         batch_dim = tf.shape(c1)[0]
         target_shape = [cv_height, cv_width, square_area, batch_dim]
         cv = tf.scatter_nd(all_indices, all_costs, target_shape)

--- a/pwcnet/cost_volume/cost_volume_test.py
+++ b/pwcnet/cost_volume/cost_volume_test.py
@@ -5,7 +5,7 @@ import time
 from pwcnet.cost_volume.cost_volume import cost_volume
 
 
-PROFILE = True
+PROFILE = False
 
 
 class TestCostVolume(unittest.TestCase):
@@ -187,8 +187,7 @@ class TestCostVolume(unittest.TestCase):
         if not PROFILE:
             return
 
-        image_shape = (32, 128, 128, 64)
-        #image_shape = (8, 128, 128, 32)
+        image_shape = (8, 128, 128, 32)
         test_runs = 100
         c1 = np.zeros(image_shape)
         c2 = np.ones(image_shape)

--- a/pwcnet/cost_volume/cost_volume_test.py
+++ b/pwcnet/cost_volume/cost_volume_test.py
@@ -5,7 +5,7 @@ import time
 from pwcnet.cost_volume.cost_volume import cost_volume
 
 
-PROFILE = False
+PROFILE = True
 
 
 class TestCostVolume(unittest.TestCase):
@@ -188,6 +188,7 @@ class TestCostVolume(unittest.TestCase):
             return
 
         image_shape = (32, 128, 128, 64)
+        #image_shape = (8, 128, 128, 32)
         test_runs = 100
         c1 = np.zeros(image_shape)
         c2 = np.ones(image_shape)

--- a/pwcnet/cost_volume/cost_volume_test.py
+++ b/pwcnet/cost_volume/cost_volume_test.py
@@ -1,7 +1,11 @@
 import numpy as np
 import tensorflow as tf
 import unittest
+import time
 from pwcnet.cost_volume.cost_volume import cost_volume
+
+
+PROFILE = False
 
 
 class TestCostVolume(unittest.TestCase):
@@ -178,6 +182,29 @@ class TestCostVolume(unittest.TestCase):
         cv = cost_volume(input1, input2, 1)
         cv = self.sess.run(cv, feed_dict={input1: c1, input2: c2})
         self.assertEqual(np.squeeze(cv).tolist(), expected.tolist())
+
+    def testPerformance(self):
+        if not PROFILE:
+            return
+
+        image_shape = (32, 128, 128, 64)
+        test_runs = 100
+        c1 = np.zeros(image_shape)
+        c2 = np.ones(image_shape)
+        input1 = tf.placeholder(shape=image_shape, dtype=tf.float32)
+        input2 = tf.placeholder(shape=image_shape, dtype=tf.float32)
+        cv = cost_volume(input1, input2, 4)
+        run_times = []
+        for i in range(test_runs + 5):
+            t1 = time.time()
+            _ = self.sess.run(cv, feed_dict={input1: c1, input2: c2})
+            if i > 4:
+                run_times.append(time.time() - t1)
+                print('Current cost volume runtime: %.3f' % run_times[-1])
+
+        print('Average cost volume runtime: %.3f' % np.average(run_times))
+
+
 
 
 if __name__ == '__main__':

--- a/pwcnet/cost_volume/cost_volume_test.py
+++ b/pwcnet/cost_volume/cost_volume_test.py
@@ -26,7 +26,6 @@ class TestCostVolume(unittest.TestCase):
         cv = self.sess.run(cv, feed_dict={input1: c1, input2: c2})
         self.assertEqual(cv.tolist(), expected.tolist())
 
-
     def testTinyImageOnesSearch0(self):
         image_shape = (1, 2, 2, 1)
         c1 = np.ones(image_shape)

--- a/utils/misc.py
+++ b/utils/misc.py
@@ -1,14 +1,17 @@
 import numpy as np
 import tensorflow as tf
+import sys
 
 
 def print_tensor_shape(x):
     print(x.get_shape().as_list())
 
+
 def tf_coin_flip(heads_rate):
     rand_val = tf.random_uniform([1], minval=0.0, maxval=1.0)
     is_head = tf.less(rand_val, heads_rate)
     return is_head
+
 
 # https://github.com/tensorflow/tensorflow/issues/7712
 def pelu(x):
@@ -20,6 +23,7 @@ def pelu(x):
         positive = tf.nn.relu(x) * alpha / (beta + 1e-9)
         negative = alpha * (tf.exp((-tf.nn.relu(-x)) / (beta + 1e-9)) - 1)
         return negative + positive
+
 
 # https://stackoverflow.com/questions/39975676/how-to-implement-prelu-activation-in-tensorflow
 def prelu(_x):


### PR DESCRIPTION
Improved the original cost volume function marginally (pretty negligible) by using 1 `tf.scatter_nd` towards the end. Also wrote a separate version that applies `tf.reduce_mean` once, outside of the loop -- it's significantly faster but also takes up a lot of memory. This version is named `cost_volume_grouped_reduce`. Some performance information below.

Test setup:
- Ran on a P100 GPU
- Input feature tensors of shape [8, 128, 128, 32]
- Averaged over 100 iterations

Times:
- Original cost volume average time: 0.130 s
- Grouped reduce_mean'd cost volume average time: 0.060 s
- Grouped reduce_mean + gather average time: 0.058 s
