### PR TITLE
Davis directory walking is now sorted.

### DIFF
--- a/data/interp/davis/davis_data.py
+++ b/data/interp/davis/davis_data.py
@@ -29,7 +29,7 @@ class DavisDataSet(InterpDataSet):
         """
         image_names = []
         extensions = ['*.jpg']
-        for item in os.listdir(raw_directory):
+        for item in sorted(os.listdir(raw_directory)):
             path = os.path.join(raw_directory, item)
             if os.path.isdir(path):
                 cur_names = []


### PR DESCRIPTION
Prevent tests from failing on other operating systems that traverse directories in a different order.