### PR TITLE
Fixes #45. Switched to tf.keras.layers implementation of PReLU to fix…

### DIFF
--- a/common/utils/tf.py
+++ b/common/utils/tf.py
@@ -36,16 +36,13 @@ def pelu(x):
         return negative + positive
 
 
-# https://stackoverflow.com/questions/39975676/how-to-implement-prelu-activation-in-tensorflow
 def prelu(_x):
-    with tf.variable_scope(_x.op.name + '_activation', initializer=tf.constant_initializer(1.0)):
-        alphas = tf.get_variable('alpha', _x.get_shape()[-1],
-                           initializer=tf.constant_initializer(0.0),
-                            dtype=tf.float32)
-        pos = tf.nn.relu(_x)
-        neg = alphas * (_x - abs(_x)) * 0.5
-
-        return pos + neg
+    """
+    :param _x: Tensor of shape [batch_size, H, W, C].
+    :return: Prelu'd tensor of shape [batch_size, H, W, C].
+    """
+    layer = tf.keras.layers.PReLU(shared_axes=[1, 2])
+    return layer(_x)
 
 
 def sliding_window_slice(x, slice_locations):

--- a/context_interp/gridnet/connections/connections.py
+++ b/context_interp/gridnet/connections/connections.py
@@ -27,10 +27,10 @@ class LateralConnection(ConvNetwork):
 
         self.total_dropout_rate = total_dropout_rate
 
-    def get_forward(self, features, reuse_variables=False, training=False):
+    def get_forward(self, features, reuse_variables=tf.AUTO_REUSE, training=False):
         """
         :param features: Tensor. Feature map of shape [batch_size, H, W, num_features].
-        :param reuse_variables: Bool. Whether to reuse the variables.
+        :param reuse_variables: tf reuse option. i.e. tf.AUTO_REUSE.
         :param training: Bool. Whether the graph is to be constructed for training.
         :return: Tensor. Feature map of shape [batch_size, H, W, num_features].
         """
@@ -81,10 +81,10 @@ class DownSamplingConnection(ConvNetwork):
                          activation_fn=activation_fn, last_activation_fn=None,
                          regularizer=regularizer, padding='SAME')
 
-    def get_forward(self, features, reuse_variables=False):
+    def get_forward(self, features, reuse_variables=tf.AUTO_REUSE):
         """
         :param features: Tensor. Feature map of shape [batch_size, H, W, num_features].
-        :param reuse_variables: Bool. Whether to reuse the variables.
+        :param reuse_variables: tf reuse option. i.e. tf.AUTO_REUSE.
         :return: Tensor. Feature map of shape [batch_size, H, W, num_features].
         """
         with tf.variable_scope(self.name, reuse=reuse_variables):
@@ -116,10 +116,10 @@ class UpSamplingConnection(ConvNetwork):
                          activation_fn=activation_fn, last_activation_fn=None,
                          regularizer=regularizer, padding='SAME')
 
-    def get_forward(self, features, reuse_variables=False):
+    def get_forward(self, features, reuse_variables=tf.AUTO_REUSE):
         """
         :param features: Tensor. Feature map of shape [batch_size, H, W, num_features].
-        :param reuse_variables: Bool. Whether to reuse the variables.
+        :param reuse_variables: tf reuse option. i.e. tf.AUTO_REUSE.
         :return: Tensor. Feature map of shape [batch_size, H, W, num_features].
         """
         with tf.variable_scope(self.name, reuse=reuse_variables):

--- a/context_interp/gridnet/connections/connections_test.py
+++ b/context_interp/gridnet/connections/connections_test.py
@@ -63,6 +63,11 @@ class TestConnections(unittest.TestCase):
         self.assertEqual(len(trainable_vars), 2 * len(specs))
         self.assertEqual(trainable_vars[2].name, name + '/conv_1/kernel:0')
 
+        # Test that getting forward again with tf.AUTO_REUSE will not increase the number of variables.
+        num_trainable_vars = len(tf.trainable_variables())
+        connection.get_forward(input_features_tensor, reuse_variables=tf.AUTO_REUSE)
+        self.assertEqual(num_trainable_vars, len(tf.trainable_variables()))
+
     def test_downsampling(self):
         """
         Sets up the network's forward pass and ensures that all shapes are expected.
@@ -116,6 +121,11 @@ class TestConnections(unittest.TestCase):
         self.assertEqual(len(trainable_vars), 2 * len(specs))
         self.assertEqual(trainable_vars[2].name, name + '/conv_1/kernel:0')
 
+        # Test that getting forward again with tf.AUTO_REUSE will not increase the number of variables.
+        num_trainable_vars = len(tf.trainable_variables())
+        connection.get_forward(input_features_tensor, reuse_variables=tf.AUTO_REUSE)
+        self.assertEqual(num_trainable_vars, len(tf.trainable_variables()))
+
     def test_upsampling(self):
         """
         Sets up the network's forward pass and ensures that all shapes are expected.
@@ -166,6 +176,11 @@ class TestConnections(unittest.TestCase):
         trainable_vars = tf.trainable_variables(scope=name)
         self.assertEqual(len(trainable_vars), 2 * len(specs))
         self.assertEqual(trainable_vars[0].name, name + '/conv_0/kernel:0')
+
+        # Test that getting forward again with tf.AUTO_REUSE will not increase the number of variables.
+        num_trainable_vars = len(tf.trainable_variables())
+        connection.get_forward(input_features_tensor, reuse_variables=tf.AUTO_REUSE)
+        self.assertEqual(num_trainable_vars, len(tf.trainable_variables()))
 
     def test_lateral_dropout(self):
         """

--- a/context_interp/gridnet/model_test.py
+++ b/context_interp/gridnet/model_test.py
@@ -116,7 +116,7 @@ class TestGridNet(unittest.TestCase):
         # Each parametric ReLU has a trainable alpha variable.
         trainable_vars = tf.trainable_variables(scope=name)
         self.assertEqual(len(trainable_vars), num_total_convs * 3)
-        self.assertEqual(trainable_vars[1].name, name + '/right_00/conv_0/kernel:0')
+        self.assertEqual(trainable_vars[1].name, name + '/right_0_0/conv_0/kernel:0')
 
         # Check that the gradients are flowing.
         grad_op = tf.gradients(final_output,
@@ -185,15 +185,6 @@ class TestGridNet(unittest.TestCase):
         self.assertEqual(np.sum(final_output_np), 0.0)
         for i in range(grid_height):
             for j in range(grid_width):
-
-                # The outputs of lateral connections should all be 0.
-                # lateral_output_only = False
-                # if (i == 0 and j < grid_width / 2) or (i == grid_height - 1 and j >= grid_width / 2):
-                #     lateral_output_only = True
-                #
-                # if lateral_output_only:
-                #     self.assertEqual(np.sum(node_outputs_np[i][j]), 0.0)
-
                 # The first lateral connection should always have non-zero output.
                 # The first column of down-sampling of streams should also have non-zero output.
                 # All other nodes have zero output when biases are zero-initialized.
@@ -221,14 +212,14 @@ class TestGridNet(unittest.TestCase):
         # Each parametric ReLU has a trainable alpha variable.
         trainable_vars = tf.trainable_variables(scope=name)
         self.assertEqual(len(trainable_vars), num_total_convs * 3)
-        self.assertEqual(trainable_vars[1].name, name + '/right_00/conv_0/kernel:0')
+        self.assertEqual(trainable_vars[1].name, name + '/right_0_0/conv_0/kernel:0')
 
         # Check gradients.
         grad_op = tf.gradients(final_output,
                                trainable_vars + [input_features_tensor])
         gradients = self.sess.run(grad_op, feed_dict={input_features_tensor: input_features})
 
-        nonzero_grad_names = {'up_03', 'up_13', 'right_04'}
+        nonzero_grad_names = {'up_0_3', 'up_1_3', 'right_0_4'}
         nonzero_sum = 0
         for i, gradient in enumerate(gradients):
             nonzero = False
@@ -241,3 +232,35 @@ class TestGridNet(unittest.TestCase):
                 self.assertEqual(np.sum(gradient), 0)
 
         self.assertNotEqual(nonzero_sum, 0)
+
+    def test_network_shares_weights(self):
+        name = 'gridnet_shared'
+        num_input_channels = 3
+        num_channels = [num_input_channels, 4, 8]
+        grid_width = 2
+        num_lateral_convs_per_connection = 1
+        num_downsampling_convs_per_connection = 3
+        num_upsampling_convs_per_connection = 3
+        gridnet = GridNet(num_channels,
+                          grid_width,
+                          name=name,
+                          connection_dropout_rate=1.0,
+                          num_lateral_convs=num_lateral_convs_per_connection,
+                          num_downsampling_convs=num_downsampling_convs_per_connection,
+                          num_upsample_convs=num_upsampling_convs_per_connection,
+                          regularizer=l2_regularizer(1e-4))
+
+        height = 32
+        width = 60
+        num_features = num_input_channels
+
+        # Create the graph.
+        input_features_tensor = tf.placeholder(shape=[None, height, width, num_features], dtype=tf.float32)
+        trainable_vars_before = len(tf.trainable_variables())
+        gridnet.get_forward(input_features_tensor, training=True, reuse_variables=tf.AUTO_REUSE)
+        trainable_vars_after = len(tf.trainable_variables())
+        self.assertGreater(trainable_vars_after, trainable_vars_before)
+
+        # Do it again and check that the number of trainable variables has not increased.
+        gridnet.get_forward(input_features_tensor, training=True, reuse_variables=tf.AUTO_REUSE)
+        self.assertEqual(trainable_vars_after, len(tf.trainable_variables()))

--- a/context_interp/model.py
+++ b/context_interp/model.py
@@ -43,7 +43,7 @@ class ContextInterp:
 
             # Get a->b and b->a flows from PWCNet.
             # TODO: Migrate to pwcnet.get_bidirectional.
-            all_flows, _ = self.pwcnet.get_forward(from_frames, to_frames)
+            all_flows, _ = self.pwcnet.get_forward(from_frames, to_frames, reuse_variables=reuse_variables)
             flow_a_b = all_flows[:batch_size]
             flow_b_a = all_flows[batch_size:]
 

--- a/context_interp/model_test.py
+++ b/context_interp/model_test.py
@@ -70,10 +70,7 @@ class TestContextInterp(unittest.TestCase):
 
         self.assertNotAlmostEqual(loss, 0.0)
 
-    def test_shared_weights(self):
-        # TODO: Enable this test after the issue is fixed.
-        return
-
+    def test_network_shares_weights(self):
         height = 128
         width = 64
         im_channels = 3

--- a/context_interp/vgg19_features/model/model.py
+++ b/context_interp/vgg19_features/model/model.py
@@ -42,13 +42,14 @@ class Vgg19:
         self.var_dict = {}
         self.dropout = dropout
 
-    def build_up_to_conv1_2(self, rgb, trainable=True):
+    def build_up_to_conv1_2(self, rgb, trainable=True, reuse_variables=tf.AUTO_REUSE):
         """
         Build VGG19 partially, up to the conv1_2 layer.
         :param rgb: rgb image [batch, height, width, 3] values scaled [0, 1].
         :param trainable: Whether the model is trainable.
+        :param reuse_variables: tf reuse option. i.e. tf.AUTO_REUSE.
         """
-        with tf.variable_scope(self.name, reuse=tf.AUTO_REUSE):
+        with tf.variable_scope(self.name, reuse=reuse_variables):
             self.var_dict = {}
             rgb_scaled = rgb * 255.0
 
@@ -65,10 +66,10 @@ class Vgg19:
             layers.conv1_2 = self.conv_layer(layers.conv1_1, 64, 64, "conv1_2", trainable)
             return layers.conv1_2, layers
 
-    def build_up_to_conv4_4(self, rgb, trainable=True):
+    def build_up_to_conv4_4(self, rgb, trainable=True, reuse_variables=tf.AUTO_REUSE):
         conv1_2, layers = self.build_up_to_conv1_2(rgb, trainable=trainable)
 
-        with tf.variable_scope(self.name, reuse=tf.AUTO_REUSE):
+        with tf.variable_scope(self.name, reuse=reuse_variables):
             layers.pool1 = self.max_pool(layers.conv1_2, 'pool1')
 
             layers.conv2_1 = self.conv_layer(layers.pool1, 64, 128, "conv2_1", trainable)

--- a/pwcnet/model.py
+++ b/pwcnet/model.py
@@ -50,6 +50,7 @@ class PWCNet(RestorableNetwork):
         """
         :param image_a: Tensor of shape [batch_size, H, W, 3].
         :param image_b: Tensor of shape [batch_size, H, W, 3].
+        :param reuse_variables: tf reuse option. i.e. tf.AUTO_REUSE.
         :return: final_flow: up-sampled final flow.
                  previous_flows: all previous flow outputs of the estimator networks and the context network.
         """


### PR DESCRIPTION
Fixes #45. The issue was that the PReLU implementation we used named variables based on the op name of the input, which changes when creating a new network to stay unique. These variable naming issues are resolved by the Layer class from which keras' PReLU inherits, so I switched to it.